### PR TITLE
[FEAT/mission5] 가게에 리뷰 추가하기 API

### DIFF
--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -1,0 +1,12 @@
+import { StatusCodes } from "http-status-codes";
+import { bodyToReview } from "../dtos/store.dto.js";
+import { createReview } from "../services/store.service.js";
+
+export const createNewReview = async (req, res, next) => {
+  console.log("미션 POST 요청");
+  console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
+  
+  const storeId = req.params.storeId;
+  const review = await createReview(bodyToReview(req.body, req.params));
+  res.status(StatusCodes.OK).json({ result: review });
+};

--- a/src/dtos/store.dto.js
+++ b/src/dtos/store.dto.js
@@ -1,0 +1,16 @@
+export const bodyToReview = (body, params) => {
+    return {
+        storeId: params.storeId,
+        starPoint: body.starPoint,
+        content: body.content,
+    };
+  };
+
+export const responseFromReview = ({user, review}) => {
+    return {
+        reviewId: review[0].id,
+        creatorNickName: user[0].name,
+        starPoint: review[0].star_point,
+        content: review[0].content,
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import { handleUserSignUp } from "./controllers/user.controller.js";
+import { createNewReview } from './controllers/store.controller.js';
 
 dotenv.config();
 
@@ -18,6 +19,7 @@ app.get('/', (req, res) => {
 })
 
 app.post("/members/information", handleUserSignUp);
+app.post("/stores/:storeId/reviews", createNewReview);
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/src/repositories/store.repository.js
+++ b/src/repositories/store.repository.js
@@ -1,0 +1,72 @@
+import { pool } from "../db.config.js";
+
+// Review 데이터 삽입
+export const addReview = async (data) => {
+  const conn = await pool.getConnection();
+
+  try {
+    const [result] = await pool.query(
+      `INSERT INTO review (star_point, member_id, store_id, content) VALUES (?, ?, ?, ?);`,
+      [
+        data.starPoint,
+        data.memberId,
+        data.storeId,
+        data.content,
+      ]
+    );
+
+    return result.insertId;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};
+
+// 리뷰 정보 얻기
+export const getReview = async (reviewId) => {
+  const conn = await pool.getConnection();
+
+  try {
+    const [review] = await pool.query(`SELECT * FROM review WHERE id = ?;`, reviewId);
+
+    console.log(review);
+
+    if (review.length == 0) {
+      return null;
+    }
+
+    return review;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};
+
+// 가게 정보 얻기
+export const getStore = async (storeId) => {
+  const conn = await pool.getConnection();
+
+  try {
+    const [store] = await pool.query(`SELECT * FROM store WHERE id = ?;`, storeId);
+
+    console.log(store);
+
+    if (store.length == 0) {
+      return null;
+    }
+
+    return store;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};

--- a/src/services/store.service.js
+++ b/src/services/store.service.js
@@ -1,0 +1,36 @@
+import { responseFromReview } from "../dtos/store.dto.js";
+import {
+  getUser,
+} from "../repositories/user.repository.js";
+import {
+    getStore,
+    addReview,
+    getReview,
+} from "../repositories/store.repository.js";
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const createReview = async (data) => {
+    const userId = process.env.DEFAULT_USER_ID;
+    const user = await getUser(userId);
+    if (user === null) {
+        throw new Error("USER NOT FOUND");
+    }
+
+    const store = await getStore(data.storeId);
+    //가게의 존재 여부 검증
+    if (store === null) {
+        throw new Error("STORE NOT FOUND");
+    }
+    
+    //addReview
+    const joinReviewId = await addReview({
+        starPoint: data.starPoint,
+        memberId: userId,
+        storeId: data.storeId,
+        content: data.content,
+    });
+    const review = await getReview(joinReviewId);
+    return responseFromReview({ user, review });
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #3  

## ✅ 구현 내용

- pathvariable에 해당하는 id의 가게에 리뷰를 추가할 수 있다.
- 가게 존재 여부 검증 수행

## 📸 스크린샷
[👍 성공 200]
![image](https://github.com/user-attachments/assets/721eace4-22c1-4e4b-8290-44cfde720232)

[👎 에러 500 - 가게의 존재 여부 검증]
![image](https://github.com/user-attachments/assets/fa7a8f49-38c0-400e-8f05-5eef33273968)

## 📝  메모
이미지와 accessToken 관련한 부분을 제외하고 기본적인 뼈대만 구현하였습니다.
userId 정보는 accessToken 대신 환경변수로 default 사용자를 정하여 처리하도록 구현했습니다.