### PR TITLE
[FEAT/mission5] 가게에 미션 추가하기 API

### DIFF
--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -1,12 +1,19 @@
 import { StatusCodes } from "http-status-codes";
 import { bodyToReview } from "../dtos/store.dto.js";
+import { bodyToMission } from "../dtos/store.dto.js";
 import { createReview } from "../services/store.service.js";
+import { createMission } from "../services/store.service.js";
 
 export const createNewReview = async (req, res, next) => {
-  console.log("미션 POST 요청");
+  console.log("리뷰 POST 요청");
   console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
-  
-  const storeId = req.params.storeId;
   const review = await createReview(bodyToReview(req.body, req.params));
   res.status(StatusCodes.OK).json({ result: review });
 };
+
+export const createNewMission = async (req, res, next) => {
+    console.log("미션 POST 요청");
+    console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
+    const mission = await createMission(bodyToMission(req.body, req.params));
+    res.status(StatusCodes.OK).json({ result: mission });
+  };

--- a/src/dtos/store.dto.js
+++ b/src/dtos/store.dto.js
@@ -14,3 +14,23 @@ export const responseFromReview = ({user, review}) => {
         content: review[0].content,
     };
 };
+
+export const bodyToMission = (body, params) => {
+    const deadline = new Date(body.deadline);
+    return {
+        storeId: params.storeId,
+        cond: body.cond,
+        reward: body.reward,
+        deadline: deadline,
+    };
+};
+
+export const responseFromMission = ({store, mission}) => {
+    return {
+        missionId: mission[0].id,
+        storeName: store[0].name,
+        cond: mission[0].cond,
+        reward: mission[0].reward,
+        deadline: mission[0].deadline,
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import { handleUserSignUp } from "./controllers/user.controller.js";
-import { createNewReview } from './controllers/store.controller.js';
+import { createNewReview, createNewMission } from './controllers/store.controller.js';
 
 dotenv.config();
 
@@ -20,6 +20,7 @@ app.get('/', (req, res) => {
 
 app.post("/members/information", handleUserSignUp);
 app.post("/stores/:storeId/reviews", createNewReview);
+app.post("/stores/:storeId/missions", createNewMission);
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/src/repositories/mission.repository.js
+++ b/src/repositories/mission.repository.js
@@ -1,0 +1,49 @@
+import { pool } from "../db.config.js";
+
+// Mission 데이터 삽입
+export const addMission = async (data) => {
+  const conn = await pool.getConnection();
+
+  try {
+    const [result] = await pool.query(
+      `INSERT INTO mission (reward, store_id, cond, deadline) VALUES (?, ?, ?, ?);`,
+      [
+        data.reward,
+        data.storeId,
+        data.cond,
+        data.deadline,
+      ]
+    );
+
+    return result.insertId;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};
+
+// 미션 정보 얻기
+export const getMission = async (missionId) => {
+  const conn = await pool.getConnection();
+
+  try {
+    const [mission] = await pool.query(`SELECT * FROM mission WHERE id = ?;`, missionId);
+
+    console.log(mission);
+
+    if (mission.length == 0) {
+      return null;
+    }
+
+    return mission;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};

--- a/src/services/store.service.js
+++ b/src/services/store.service.js
@@ -1,4 +1,4 @@
-import { responseFromReview } from "../dtos/store.dto.js";
+import { responseFromMission, responseFromReview } from "../dtos/store.dto.js";
 import {
   getUser,
 } from "../repositories/user.repository.js";
@@ -7,6 +7,10 @@ import {
     addReview,
     getReview,
 } from "../repositories/store.repository.js";
+import {
+    getMission,
+    addMission
+} from "../repositories/mission.repository.js";
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -33,4 +37,22 @@ export const createReview = async (data) => {
     });
     const review = await getReview(joinReviewId);
     return responseFromReview({ user, review });
+}
+
+export const createMission = async (data) => {
+    const store = await getStore(data.storeId);
+    //가게의 존재 여부 검증
+    if (store === null) {
+        throw new Error("STORE NOT FOUND");
+    }
+
+    //addMission
+    const joinMissionId = await addMission({
+        reward: data.reward,
+        storeId: data.storeId,
+        cond: data.cond,
+        deadline: data.deadline,
+    });
+    const mission = await getMission(joinMissionId);
+    return responseFromMission({ store, mission });
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #4 

## ✅ 구현 내용

- pathvariable에 해당하는 id의 가게에 미션을 추가할 수 있다.
- 가게 존재 여부 검증 수행

## 📸 스크린샷
[👍 성공 200]
![image](https://github.com/user-attachments/assets/58b8a43f-6af9-4b41-9170-137ac064c479)

[👎 에러 500 - 가게의 존재 여부 검증]
![image](https://github.com/user-attachments/assets/35df00db-c3be-40dd-aa3b-5e353dee1f74)

## 📝  메모
accessToken과 미션 관련 unique 검증은 제외하고 뼈대만 구현하였습니다.
마감기한의 경우, 2025-04-30 23:59:59까지라면, 2025-05-01을 넣도록 구현하였습니다.