### PR TITLE
[FEAT/mission5] 미션 도전하기 API

### DIFF
--- a/src/controllers/mission.controller.js
+++ b/src/controllers/mission.controller.js
@@ -1,0 +1,9 @@
+import { StatusCodes } from "http-status-codes";
+import { bodyToMemberMission } from "../dtos/mission.dto.js";
+import { challengeMission } from "../services/mission.service.js";
+
+export const handleMissionChallenge = async (req, res, next) => {
+    console.log("미션 도전!");
+    const memberMission = await challengeMission(bodyToMemberMission(req.params));
+    res.status(StatusCodes.OK).json({ result: memberMission });
+};

--- a/src/dtos/mission.dto.js
+++ b/src/dtos/mission.dto.js
@@ -1,0 +1,15 @@
+export const bodyToMemberMission = (params) => {
+    return {
+        missionId: params.missionId,
+    };
+};
+
+export const responseFromMemberMission = ({mission, memberMission}) => {
+    return {
+        memberMissionId : memberMission[0].id,
+        status: memberMission[0].status,
+        reward: mission[0].reward,
+        cond: mission[0].cond,
+        deadline: mission[0].deadline,
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import express from 'express';
 import cors from 'cors';
 import { handleUserSignUp } from "./controllers/user.controller.js";
 import { createNewReview, createNewMission } from './controllers/store.controller.js';
+import { handleMissionChallenge } from './controllers/mission.controller.js';
 
 dotenv.config();
 
@@ -21,6 +22,7 @@ app.get('/', (req, res) => {
 app.post("/members/information", handleUserSignUp);
 app.post("/stores/:storeId/reviews", createNewReview);
 app.post("/stores/:storeId/missions", createNewMission);
+app.post("/missions/:missionId", handleMissionChallenge);
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/src/repositories/mission.repository.js
+++ b/src/repositories/mission.repository.js
@@ -47,3 +47,62 @@ export const getMission = async (missionId) => {
     conn.release();
   }
 };
+
+// MemberMission 데이터 삽입 == mission 도전
+export const addMemberMission = async ({missionId, userId}) => {
+  const conn = await pool.getConnection();
+  
+  try {
+    const [confirm] = await pool.query(
+      `SELECT EXISTS(SELECT 1 FROM members_mission WHERE member_id = ? and mission_id = ?) as isChallenging;`,
+      [
+        userId,
+        missionId
+      ]
+    );
+      
+    if (confirm[0].isChallenging) {
+      return null;
+    }
+        
+    const [result] = await pool.query(
+      `INSERT INTO members_mission (member_id, mission_id) VALUES (?, ?);`,
+      [
+        userId,
+        missionId
+        //status의 경우 default "INCOMPLETE"으로 설정되어있음.
+      ]
+    );
+  
+    return result.insertId;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};
+
+// MemberMission 정보 얻기
+export const getMemberMission = async (memberMissionId) => {
+  const conn = await pool.getConnection();
+  
+  try {
+    const [memberMission] = await pool.query(`SELECT * FROM members_mission WHERE id = ?;`, memberMissionId);
+  
+    console.log(memberMission);
+  
+    if (memberMission.length == 0) {
+      return null;
+    }
+  
+    return memberMission;
+  } catch (err) {
+    throw new Error(
+      `오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+    );
+  } finally {
+    conn.release();
+  }
+};

--- a/src/services/mission.service.js
+++ b/src/services/mission.service.js
@@ -1,0 +1,38 @@
+import { responseFromMemberMission } from "../dtos/mission.dto.js";
+import {
+  getUser,
+} from "../repositories/user.repository.js";
+import {
+    getMission,
+    addMemberMission,
+    getMemberMission
+} from "../repositories/mission.repository.js";
+import dotenv from 'dotenv'
+
+dotenv.config();
+
+export const challengeMission = async (data) => {
+    const userId = process.env.DEFAULT_USER_ID;
+    const user = await getUser(userId);
+    if (user === null) {
+        throw new Error("USER NOT FOUND");
+    }
+
+    console.log(data.missionId);
+    const mission = await getMission(data.missionId);
+    if (mission === null) {
+        throw new Error("MISSION NOT FOUND");
+    }
+
+    const joinmemberMissionId = await addMemberMission({
+        missionId: data.missionId, 
+        userId: userId
+    });
+    //미션이 도전중인지 검증
+    if (joinmemberMissionId === null){
+        throw new Error("MISSION ALREADY UNDERWAY");
+    }
+    
+    const memberMission = await getMemberMission(joinmemberMissionId);
+    return responseFromMemberMission({ mission, memberMission });
+};


### PR DESCRIPTION
## 📌 Issue Number

- close #5 

## ✅ 구현 내용

- 가게의 미션을 도전 중인 미션에 추가하는 API.
- 도전하려는 미션이 이미 도전 중인지 검증 진행.

## 📸 스크린샷
[👍 성공 200]
![스크린샷 2025-05-02 235641](https://github.com/user-attachments/assets/16d72e70-a424-4ad4-8ef7-ee872658f0a2)

[👎 에러 500 - 가게의 존재 여부 검증]
![image](https://github.com/user-attachments/assets/b8241bcf-5a8f-4367-98dc-586946bf3321)

## 📝  메모
accessToken을 통한 user인증은 제외하고 뼈대만 구현하였습니다.
Membermission 테이블에 해당 미션과 해당 user에 대한 레코드가 존재하는지 체크하여 미션의 도전 여부를 검증하였기 때문에 만약 같은 미션에 대해 마감 기한을 다르게 하여 중복 도전이 가능할 경우, 검증 로직을 바꿀 필요가 있음.
해당 API의 URI에 대해 고민해 볼 필요가 있음.