### PR TITLE
[FEAT/mission6] : 내가 작성한 리뷰 목록 조회 API 구현

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import { bodyToUser } from "../dtos/user.dto.js";
-import { userSignUp } from "../services/user.service.js";
+import { userSignUp, listMemberReviews } from "../services/user.service.js";
 
 export const handleUserSignUp = async (req, res, next) => {
   console.log("회원가입을 요청했습니다!");
@@ -9,3 +9,10 @@ export const handleUserSignUp = async (req, res, next) => {
   const user = await userSignUp(bodyToUser(req.body));
   res.status(StatusCodes.OK).json({ result: user });
 };
+
+export const handleListMemberReviews = async (req, res, next) => {
+  const reviews = await listMemberReviews(
+    typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0
+  );
+  res.status(StatusCodes.OK).json(reviews);
+}

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -24,3 +24,15 @@ export const responseFromUser = ({user, preferences}) => {
         preferences: categoryNames,
     };
 };
+
+export const responseFromReveiws = ({user, reviews}) => {
+  return {
+      data: {
+        reviews: reviews,
+        member: user
+      },
+      pagination: {
+          cursor: reviews.length ? reviews[reviews.length - 1].id : null
+      },
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
-import { handleUserSignUp } from "./controllers/user.controller.js";
+import {
+  handleUserSignUp,
+  handleListMemberReviews
+} from "./controllers/user.controller.js";
 import {
   createNewReview,
   createNewMission,
@@ -31,6 +34,7 @@ app.post("/missions/:missionId", handleMissionChallenge);
 
 //week6
 app.get("/stores/:storeId/reviews", handleListStoreReviews);
+app.get("/members/reviews", handleListMemberReviews);
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -42,3 +42,21 @@ export const getUserPreferencesByUserId = async (userId) => {
 
   return preferences;
 };
+
+// 사용자 별 리뷰 반환
+export const getAllReviewsByMember = async(userId, cursor) => {
+  const reviews = await prisma.review.findMany({
+    select: {
+      id: true,
+      description: true,
+      storeId: true,
+      memberId: true,
+      store: true,
+      //member는 중복되는 정보이므로 responseDTO에서 한번만 처리하도록 함.
+    },
+    where: { memberId: userId, id: {gt: cursor}},
+    orderBy: { id: "asc"},
+    take: 5,
+  });
+  return reviews;
+}

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,10 +1,14 @@
-import { responseFromUser } from "../dtos/user.dto.js";
+import { responseFromUser, responseFromReveiws } from "../dtos/user.dto.js";
 import {
   addUser,
   getUser,
   getUserPreferencesByUserId,
   setPreference,
+  getAllReviewsByMember
 } from "../repositories/user.repository.js";
+import dotenv from 'dotenv'
+
+dotenv.config();
 
 export const userSignUp = async (data) => {
   const joinUserId = await addUser({
@@ -30,3 +34,10 @@ export const userSignUp = async (data) => {
 
   return responseFromUser({ user, preferences });
 };
+
+export const listMemberReviews = async (cursor) => {
+  const userId = parseInt(process.env.DEFAULT_USER_ID);
+  const user = await getUser(userId);
+  const reviews = await getAllReviewsByMember(userId, cursor);
+  return responseFromReveiws({user, reviews});
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #16 

## ✅ 구현 내용

- 멤버 별 작성한 리뷰를 조회하는 API 구현
- 페이지네이션 적용

## 📸 스크린샷
[👍 성공, 목록이 있을 때]
![image](https://github.com/user-attachments/assets/a1c1baff-4ece-4324-ac83-d6e5bf8e1c6e)

[👍 성공, 목록이 없을 때]
![image](https://github.com/user-attachments/assets/3b5a2d7b-67bf-43f3-b4bd-bb5981e67346)

## 📝  메모
- accessToken 관련 내용 제외하고 구현
- 3주차 API 설계에는 orderBy 기준이 최신순이었는데, 그냥 id 기준으로 정렬했습니다...
- 리뷰에 대해 member 값이 다소 중복되는데, response를 보낼 때 중복을 제거하는 게 좋은지 아니면 워크북대로 보내는 것이 나은지가 궁금합니다.