### PR TITLE
[FEAT/mission6] 진행중인 미션을 진행완료로 변경하는 API 구현

### DIFF
--- a/prisma/migrations/20250508081735_add_point_to_member/migration.sql
+++ b/prisma/migrations/20250508081735_add_point_to_member/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `member` ADD COLUMN `points` INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Member {
   birth         DateTime @db.Date
   address       String   @db.VarChar(255)
   detailAddress String?  @map("detail_address") @db.VarChar(255)
+  points        Int      @default(0)
 
   UserFavorCategory UserFavorCategory[]
   review Review[]

--- a/src/controllers/mission.controller.js
+++ b/src/controllers/mission.controller.js
@@ -1,9 +1,16 @@
 import { StatusCodes } from "http-status-codes";
 import { bodyToMemberMission } from "../dtos/mission.dto.js";
-import { challengeMission } from "../services/mission.service.js";
+import { challengeMission, completeMission } from "../services/mission.service.js";
 
 export const handleMissionChallenge = async (req, res, next) => {
     console.log("미션 도전!");
     const memberMission = await challengeMission(bodyToMemberMission(req.params));
+    res.status(StatusCodes.OK).json({ result: memberMission });
+};
+
+export const handleMissionSuccess = async (req, res, next) => {
+    const memberMission = await completeMission(
+        parseInt(req.params.missionId)
+    );
     res.status(StatusCodes.OK).json({ result: memberMission });
 };

--- a/src/dtos/mission.dto.js
+++ b/src/dtos/mission.dto.js
@@ -13,3 +13,10 @@ export const responseFromMemberMission = ({mission, memberMission}) => {
         deadline: mission.deadline,
     };
 };
+
+export const responseFromMissionSuccess = ({memberMission, member}) => {
+    return {
+        status : memberMission.state,
+        points : member.points
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import {
   handleListStoreReviews,
   handleListStoreMissions
 } from './controllers/store.controller.js';
-import { handleMissionChallenge } from './controllers/mission.controller.js';
+import { handleMissionChallenge, handleMissionSuccess } from './controllers/mission.controller.js';
 
 dotenv.config();
 
@@ -37,6 +37,7 @@ app.post("/missions/:missionId", handleMissionChallenge);
 app.get("/stores/:storeId/reviews", handleListStoreReviews);
 app.get("/members/reviews", handleListMemberReviews);
 app.get("/stores/:storeId/missions", handleListStoreMissions);
+app.post("/missions/:missionId/success", handleMissionSuccess);
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/src/repositories/mission.repository.js
+++ b/src/repositories/mission.repository.js
@@ -1,3 +1,4 @@
+import { MissionStatus } from "@prisma/client";
 import { prisma } from "../db.config.js";
 
 // Mission 데이터 삽입
@@ -32,3 +33,53 @@ export const getMemberMission = async (memberMissionId) => {
   const memberMission = await prisma.memberMission.findFirstOrThrow({where: {id: memberMissionId}});
   return memberMission;
 };
+
+//미션에 대한 검증 수행
+export const ifMissionChallenging = async({memberId, missionId}) => {
+  const memberMission = await prisma.memberMission.findFirstOrThrow({where: {memberId: memberId, missionId: missionId}})
+  //미션 상태가 진행중인지 검증
+  if (!memberMission || memberMission.state !== MissionStatus.INCOMPLETE ){
+    return null;
+  }
+  //미션 데드라인 검증
+  const mission = await prisma.mission.findFirstOrThrow({
+    where: {id: memberMission.missionId },
+    select: {
+      id: true,
+      deadline: true,
+    },
+  });
+  if (new Date() > mission.deadline) {
+    return null;
+  }
+  return memberMission.id;
+}
+
+//미션 상태 바꾸기 + member point update
+export const updateStatusOfMemberMission = async({memberId, memberMissionId}) => {
+  return await prisma.$transaction(async (tx) => {
+    //미션 상태 업데이트
+    const updatedMemberMission = await tx.memberMission.update({
+      where: {id: memberMissionId },
+      data: {
+        state: MissionStatus.COMPLETE,
+      },
+    });
+    //포인트 업데이트
+    const mission = await tx.mission.findFirstOrThrow({
+      where: {id: updatedMemberMission.missionId},
+      select: {
+        reward: true,
+      },
+    });
+    await tx.member.update({
+      where: {id: memberId},
+      data: {
+        points: {
+          increment: mission.reward,
+        },
+      },
+    });
+    return updatedMemberMission.id;
+  });
+}

--- a/src/services/mission.service.js
+++ b/src/services/mission.service.js
@@ -1,11 +1,13 @@
-import { responseFromMemberMission } from "../dtos/mission.dto.js";
+import { responseFromMemberMission, responseFromMissionSuccess } from "../dtos/mission.dto.js";
 import {
   getUser,
 } from "../repositories/user.repository.js";
 import {
     getMission,
     addMemberMission,
-    getMemberMission
+    getMemberMission,
+    updateStatusOfMemberMission,
+    ifMissionChallenging
 } from "../repositories/mission.repository.js";
 import dotenv from 'dotenv'
 
@@ -36,3 +38,35 @@ export const challengeMission = async (data) => {
     const memberMission = await getMemberMission(joinmemberMissionId);
     return responseFromMemberMission({ mission, memberMission });
 };
+
+export const completeMission = async(missionId) => {
+    const userId = parseInt(process.env.DEFAULT_USER_ID);
+    const user = await getUser(userId);
+    if (user === null) {
+        throw new Error("USER NOT FOUND");
+    }
+    
+    const mission = await getMission(missionId);
+    if (mission === null) {
+        throw new Error("MISSION NOT FOUND");
+    }
+
+    //valid Check
+    const memberMissionId = await ifMissionChallenging({
+        memberId: userId,
+        missionId: missionId,
+    });
+    if(memberMissionId === null) {
+        throw new Error("MISSION STATE IS NOT VALID");
+    }
+    
+    //업데이트 로직 수행
+    const updateMemberMissionId = await updateStatusOfMemberMission({
+        memberId: userId,
+        memberMissionId: memberMissionId,
+    });
+
+    const memberMission = await getMemberMission(updateMemberMissionId);
+    const updateUser = await getUser(userId);
+    return responseFromMissionSuccess({memberMission: memberMission, member: updateUser});
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #20 

## ✅ 구현 내용

- 미션 성공하기 API
- 미션이 진행중인지에 대한 검증 진행
- 미션의 마감기한에 대한 검증 진행
- 트랜잭션 이용하여 미션의 상태와 멤버의 포인트 업데이트를 안전하게 할 수 있도록 구현

## 📸 스크린샷
[👍 성공 200]
- 이전 (INCOMPLETE, points = 1100)
![image](https://github.com/user-attachments/assets/545c5692-bd88-49d8-9606-c7ef97ae78e5)
![image](https://github.com/user-attachments/assets/5229e0ba-fffb-49c6-ae6f-033f7daa1a28)

- 이후 (COMPLETE, points = 1500)
![image](https://github.com/user-attachments/assets/f783ae3f-445c-4e82-8de7-4c6c9e8196d2)
![image](https://github.com/user-attachments/assets/88d5ad84-a438-45cc-a14f-719d1e202d4a)

[👎 에러 500, 검증 실패(미션이 진행중이 아니거나 마감기한이 지난 경우)]
![image](https://github.com/user-attachments/assets/6fb94f03-19f4-4414-a5e5-c5c3049d3101)

## 📝  메모
- 미션의 수행이 중복 불가하다고 가정하여 구현함.
- userId는 accessToken 관련 로직이 구현되지 않아 환경변수로 처리하도록 함.