### PR TITLE
[REFACTOR/mission7] API 응답 통일 및 오류 응답 개선

### DIFF
--- a/src/controllers/mission.controller.js
+++ b/src/controllers/mission.controller.js
@@ -5,12 +5,12 @@ import { challengeMission, completeMission } from "../services/mission.service.j
 export const handleMissionChallenge = async (req, res, next) => {
     console.log("미션 도전!");
     const memberMission = await challengeMission(bodyToMemberMission(req.params));
-    res.status(StatusCodes.OK).json({ result: memberMission });
+    res.status(StatusCodes.OK).success(memberMission);
 };
 
 export const handleMissionSuccess = async (req, res, next) => {
     const memberMission = await completeMission(
         parseInt(req.params.missionId)
     );
-    res.status(StatusCodes.OK).json({ result: memberMission });
+    res.status(StatusCodes.OK).success(memberMission);
 };

--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -12,14 +12,14 @@ export const createNewReview = async (req, res, next) => {
   console.log("리뷰 POST 요청");
   console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
   const review = await createReview(bodyToReview(req.body, req.params));
-  res.status(StatusCodes.OK).json({ result: review });
+  res.status(StatusCodes.OK).success(review);
 };
 
 export const createNewMission = async (req, res, next) => {
     console.log("미션 POST 요청");
     console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
     const mission = await createMission(bodyToMission(req.body, req.params));
-    res.status(StatusCodes.OK).json({ result: mission });
+    res.status(StatusCodes.OK).success(mission);
   };
 
 export const handleListStoreReviews = async (req, res, next) => {
@@ -27,7 +27,7 @@ export const handleListStoreReviews = async (req, res, next) => {
     parseInt(req.params.storeId),
     typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0
   );
-  res.status(StatusCodes.OK).json(reviews);
+  res.status(StatusCodes.OK).success(reviews);
 };
 
 export const handleListStoreMissions = async (req, res, next) => {
@@ -35,5 +35,5 @@ export const handleListStoreMissions = async (req, res, next) => {
     parseInt(req.params.storeId),
     typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0
   );
-  res.status(StatusCodes.OK).json(missions);
+  res.status(StatusCodes.OK).success(missions);
 }

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -14,5 +14,5 @@ export const handleListMemberReviews = async (req, res, next) => {
   const reviews = await listMemberReviews(
     typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0
   );
-  res.status(StatusCodes.OK).json(reviews);
+  res.status(StatusCodes.OK).success(reviews);
 }

--- a/src/error.js
+++ b/src/error.js
@@ -1,9 +1,36 @@
-export class DuplicateUserEmailError extends Error {
-    errorCode = "U001";
-
-    constructor(reason, data) {
+export class CustomError extends Error {
+    constructor(reason, errorCode, statusCode, data = null) {
         super(reason);
         this.reason = reason;
+        this.name = this.constructor.name;
+        this.errorCode = errorCode;
+        this.statusCode = statusCode;
         this.data = data;
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+//피클 깃허브 염탐했어요..ㅎ
+
+export class DuplicateUserEmailError extends CustomError {
+    constructor(reason, data = null) {
+        super(reason, "U001", 400, data);
+    }
+}
+
+export class NotExistsError extends CustomError {
+    constructor(reason, data = null) {
+        super(reason, "NOT_EXISTS", 404, data);
+    }
+}
+
+export class AlreadyUnderwayMissionError extends CustomError {
+    constructor(reason, data = null) {
+        super(reason, "M001", 400, data);
+    }
+}
+
+export class InvalidToCompleteMissionError extends CustomError {
+    constructor(reason, data = null) {
+        super(reason, "M002", 403, data);
     }
 }

--- a/src/services/mission.service.js
+++ b/src/services/mission.service.js
@@ -10,6 +10,11 @@ import {
     ifMissionChallenging
 } from "../repositories/mission.repository.js";
 import dotenv from 'dotenv'
+import {
+    NotExistsError,
+    AlreadyUnderwayMissionError,
+    InvalidToCompleteMissionError
+} from "../error.js";
 
 dotenv.config();
 
@@ -17,13 +22,13 @@ export const challengeMission = async (data) => {
     const userId = parseInt(process.env.DEFAULT_USER_ID);
     const user = await getUser(userId);
     if (user === null) {
-        throw new Error("USER NOT FOUND");
+        throw new NotExistsError("USER NOT FOUND", {id: userId});
     }
 
     console.log(data.missionId);
     const mission = await getMission(data.missionId);
     if (mission === null) {
-        throw new Error("MISSION NOT FOUND");
+        throw new NotExistsError("MISSION NOT FOUND", {id: data.missionId});
     }
 
     const joinmemberMissionId = await addMemberMission({
@@ -32,7 +37,7 @@ export const challengeMission = async (data) => {
     });
     //미션이 도전중인지 검증
     if (joinmemberMissionId === null){
-        throw new Error("MISSION ALREADY UNDERWAY");
+        throw new AlreadyUnderwayMissionError("MISSION ALREADY UNDERWAY");
     }
     
     const memberMission = await getMemberMission(joinmemberMissionId);
@@ -43,12 +48,12 @@ export const completeMission = async(missionId) => {
     const userId = parseInt(process.env.DEFAULT_USER_ID);
     const user = await getUser(userId);
     if (user === null) {
-        throw new Error("USER NOT FOUND");
+        throw new NotExistsError("USER NOT FOUND", {id: userId});
     }
     
     const mission = await getMission(missionId);
     if (mission === null) {
-        throw new Error("MISSION NOT FOUND");
+        throw new NotExistsError("MISSION NOT FOUND", {id: missionId});
     }
 
     //valid Check
@@ -57,7 +62,7 @@ export const completeMission = async(missionId) => {
         missionId: missionId,
     });
     if(memberMissionId === null) {
-        throw new Error("MISSION STATE IS NOT VALID");
+        throw new InvalidToCompleteMissionError("MISSION STATE IS NOT VALID", {deadline: mission.deadline});
     }
     
     //업데이트 로직 수행

--- a/src/services/store.service.js
+++ b/src/services/store.service.js
@@ -19,6 +19,7 @@ import {
     addMission
 } from "../repositories/mission.repository.js";
 import dotenv from 'dotenv';
+import { NotExistsError } from "../error.js";
 
 dotenv.config();
 
@@ -26,13 +27,13 @@ export const createReview = async (data) => {
     const userId = parseInt(process.env.DEFAULT_USER_ID);
     const user = await getUser(userId);
     if (user === null) {
-        throw new Error("USER NOT FOUND");
+        throw new NotExistsError("USER NOT FOUND", {id: userId});
     }
 
     const store = await getStore(data.storeId);
     //가게의 존재 여부 검증
     if (store === null) {
-        throw new Error("STORE NOT FOUND");
+        throw new NotExistsError("STORE NOT FOUND", {id: data.storeId});
     }
     
     //addReview
@@ -50,7 +51,7 @@ export const createMission = async (data) => {
     const store = await getStore(data.storeId);
     //가게의 존재 여부 검증
     if (store === null) {
-        throw new Error("STORE NOT FOUND");
+        throw new NotExistsError("STORE NOT FOUND", {id: data.storeId});
     }
 
     //addMission

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -23,7 +23,7 @@ export const userSignUp = async (data) => {
   });
 
   if (joinUserId === null) {
-    throw new DuplicateUserEmailError("이미 존재하는 이메일입니다.", data);
+    throw new DuplicateUserEmailError("이미 존재하는 이메일입니다.", { email: data.email });
   }
 
   for (const preference of data.preferences) {


### PR DESCRIPTION
## 📌 Issue Number

- close #26 

## ✅ 구현 내용

- API 성공 응답 통일
- 오류 응답 개선

## 📸 스크린샷

1. 리뷰 작성하기 API
  [👍 성공 200]
![image](https://github.com/user-attachments/assets/31353727-73a7-4330-bad7-d643ad85a24a)
2. 가게 미션 생성 API
  [👍 성공 200]
![image](https://github.com/user-attachments/assets/93116b48-1016-40d3-b214-9ec812f5dee7)
3. 미션 도전 API
  [👍 성공 200]
![image](https://github.com/user-attachments/assets/3a546264-36d2-4d51-a705-eb382f6f1d36)
  [👎 에러 500]
![image](https://github.com/user-attachments/assets/c8bd589b-c138-4d84-8ce6-b6526bd10fe0)
4. 미션 성공 API
  [👍 성공 200]
![image](https://github.com/user-attachments/assets/a5dc787b-eb27-42e0-ad63-bbedc04ab02f)
  [👎 에러 500]
![image](https://github.com/user-attachments/assets/4cb4bf69-6c94-47fa-a706-63c4d64e9e6c)
5. 가게 별 리뷰 목록 조회 API
![image](https://github.com/user-attachments/assets/e375cdac-a8e1-4cd3-9873-3c48469e3440)

6. 멤버 별 리뷰 목록 조회 API
![image](https://github.com/user-attachments/assets/b4705551-9610-4bd9-a50e-0d05b8c7a274)

7. 가게 별 미션 목록 조회 API
![image](https://github.com/user-attachments/assets/99b390ac-dee3-4a84-9565-e255ed73b29d)

## 📝  메모
- 피클 깃허브를 조금 염탐했습니다😄 

> CustomError 클래스를 생성해서 다른 커스텀 에러들이 그 클래스를 extend하도록 구현하였습니다.

- 미션 성공 로직에서 데드라인 검증에 실패하거나 미션이 도전중이지 않을 때 deadline을 추가 데이터로 반환하여 어떤 검증에 실패했는지 클라이언트에서 확인 가능하도록 했습니다.
