### PR TITLE
[DOCS/mission8] Swagger 명세 작성

### DIFF
--- a/src/controllers/mission.controller.js
+++ b/src/controllers/mission.controller.js
@@ -3,24 +3,160 @@ import { bodyToMemberMission } from "../dtos/mission.dto.js";
 import { challengeMission, completeMission } from "../services/mission.service.js";
 
 export const handleMissionChallenge = async (req, res, next) => {
-    try {
-        console.log("미션 도전!");
-        const memberMission = await challengeMission(bodyToMemberMission(req.params));
-        res.status(StatusCodes.OK).success(memberMission);
-    }
-    catch(err) {
-        next(err);
-    }
+  /*
+    #swagger.tags = ["Mission"];
+    #swagger.summary = '미션 도전하기 API';
+    #swagger.responses[200] = {
+      description: "도전하기 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref : "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  allOf: [
+                    { type: "object", properties: { memberMissionId: { type: "number" }}},
+                    { $ref: "#/components/schemas/Mission" }
+                  ]
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[400] = {
+      description: "이미 도전중인 미션",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "M001" },
+                    reason: { example: "MISSION ALREADY UNDERWAY" }
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[404] = {
+      description: "NOT_EXIST_ERROR",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "NOT_FOUND" },
+                    reason: { example: "MISSION NOT FOUND" },
+                    data: { type: "object", properties: { id: { type: "number" }}}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
+  try {
+    console.log("미션 도전!");
+    const memberMission = await challengeMission(bodyToMemberMission(req.params));
+    res.status(StatusCodes.OK).success(memberMission);
+  }
+  catch(err) {
+    next(err);
+  }
 };
 
 export const handleMissionSuccess = async (req, res, next) => {
-    try {
-        const memberMission = await completeMission(
-            parseInt(req.params.missionId)
-        );
-        res.status(StatusCodes.OK).success(memberMission);
-    }
-    catch(err) {
-        next(err);
-    }
+  /*
+    #swagger.tags = ["Mission"];
+    #swagger.summary = '미션 성공으로 상태 바꾸기 API';
+    #swagger.responses[200] = {
+      description: "미션 상태 바꾸기 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref : "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  type: "object",
+                  properties: {
+                    status: { type: "string", example: "COMPLETE" },
+                    points: { type: "number" }
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[403] = {
+      description: "기한 만료 또는 이미 성공한 미션",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "M002" },
+                    reason: { example: "MISSION STATE IS NOT VALID" },
+                    data: { type: "object", properties: { deadline: { type: "string", format : "date" }}}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[404] = {
+      description: "NOT_EXIST_ERROR",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "NOT_FOUND" },
+                    reason: { example: "MISSION NOT FOUND" },
+                    data: { type: "object", properties: { id: { type: "number" }}}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
+  try {
+    const memberMission = await completeMission(
+      parseInt(req.params.missionId)
+    );
+    res.status(StatusCodes.OK).success(memberMission);
+  }
+  catch(err) {
+    next(err);
+  }
 };

--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -33,37 +33,41 @@ export const createNewMission = async (req, res, next) => {
 
 export const handleListStoreReviews = async (req, res, next) => {
   /*
+    #swagger.tags = ["Store"];
     #swagger.summary = '상점 리뷰 목록 조회 API';
     #swagger.responses[200] = {
       description: "상점 리뷰 목록 조회 성공 응답",
       content: {
         "application/json": {
           schema: {
-            type: "object",
-            properties: {
-              resultType: { type: "string", example: "SUCCESS" },
-              error: { type: "object", nullable: true, example: null },
-              success: {
-                type: "object",
-                properties: {
-                  data: {
-                    type: "array",
-                    items: {
-                      type: "object",
-                      properties: {
-                        id: { type: "number" },
-                        description: { type: "string"},
-                        starPoint: { type: "number" },
-                        store: { type: "object", properties: { id: { type: "number" }, name: { type: "string" }, roadAddress: { type: "string" }, starPoint: { type: "number" } } },
-                        member: { type: "object", properties: { name: { type: "string" } } },
-                        content: { type: "string" }
+            allOf: [ { $ref: "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: { type: "object", 
+                        properties: { 
+                          id: { type: "number" }, 
+                          description: { type: "string"},
+                          starPoint: { type: "number" },
+                          store: { type: "object", properties: {
+                            id: { type: "number" }, 
+                            name: { type: "string" }, 
+                            roadAddress: { type: "string" }, 
+                            starPoint: { type: "number" } }
+                          },
+                          member: { type: "object", properties: { name: { type: "string" } }}
+                        }
                       }
-                    }
-                  },
-                  pagination: { type: "object", properties: { cursor: { type: "number", nullable: true } }}
+                    },
+                    pagination: { type: "object", properties: { cursor: { type: "number", nullable: true } }}
+                  }
                 }
               }
-            }
+            }]
           }
         }
       }

--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -35,6 +35,7 @@ export const handleListStoreReviews = async (req, res, next) => {
   /*
     #swagger.tags = ["Store"];
     #swagger.summary = '상점 리뷰 목록 조회 API';
+    #swagger.parameters["cursor"] = { description: "Default 0, pagination/cursor 값을 다음 응답으로 넣어주세요." }
     #swagger.responses[200] = {
       description: "상점 리뷰 목록 조회 성공 응답",
       content: {
@@ -85,6 +86,46 @@ export const handleListStoreReviews = async (req, res, next) => {
 };
 
 export const handleListStoreMissions = async (req, res, next) => {
+  /*
+    #swagger.tags = ["Store"];
+    #swagger.summary = '상점 미션 목록 조회 API';
+    #swagger.parameters["cursor"] = { description: "Default 0, pagination/cursor 값을 다음 응답으로 넣어주세요." }
+    #swagger.responses[200] = {
+      description: "상점 미션 목록 조회 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: { type: "object", 
+                        properties: { 
+                          id: { type: "number" },
+                          cond: { type: "number" },
+                          deadline: { type: "string", format: "date" },
+                          reward: { type: "number" },
+                          store: { type: "object", properties: {
+                            id: { type: "number" }, 
+                            name: { type: "string" }
+                          }}
+                        }
+                      }
+                    },
+                    pagination: { type: "object", properties: { cursor: { type: "number", nullable: true } }}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
   try {
     const missions = await listStoreMissions(
       parseInt(req.params.storeId),

--- a/src/controllers/store.controller.js
+++ b/src/controllers/store.controller.js
@@ -9,6 +9,62 @@ import {
 } from "../services/store.service.js";
 
 export const createNewReview = async (req, res, next) => {
+  /*
+    #swagger.tags = ["Store"];
+    #swagger.summary = '리뷰 생성 API';
+    #swagger.requestBody = {
+      required: true, content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/Review" }
+        }
+      }
+    };
+    #swagger.responses[200] = {
+      description: "리뷰생성 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref : "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  allOf: [
+                    { type: "object", properties: {
+                      reviewId: { type: "number" },
+                      creatorNickName: { type: "string" }
+                    }},
+                    { $ref: "#/components/schemas/Review" }
+                  ]
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[404] = {
+      description: "NOT_EXIST_ERROR",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "NOT_FOUND" },
+                    reason: { example: "STORE NOT FOUND" },
+                    data: { type: "object", properties: { id: { type: "number" }}}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
   try {
     console.log("리뷰 POST 요청");
     console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
@@ -21,6 +77,63 @@ export const createNewReview = async (req, res, next) => {
 };
 
 export const createNewMission = async (req, res, next) => {
+  /*
+    #swagger.tags = ["Store"];
+    #swagger.summary = '미션 생성 API';
+    #swagger.requestBody = {
+      required: true, content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/Mission" }
+        }
+      }
+    };
+    #swagger.responses[200] = {
+      description: "미션 생성 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref : "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  allOf: [
+                    {
+                      type: "object", properties: {
+                        missionId: { type: "number" },
+                        storeName: { type: "string" }
+                      }
+                    }, { $ref: "#/components/schemas/Mission" }
+                  ]
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+    #swagger.responses[404] = {
+      description: "NOT_EXIST_ERROR",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonFailureResponse" }, {
+              type: "object",
+              properties: {
+                error: {
+                  type: "object",
+                  properties: {
+                    errorCode: { example : "NOT_FOUND" },
+                    reason: { example: "STORE NOT FOUND" },
+                    data: { type: "object", properties: { id: { type: "number" }}}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
   try{
     console.log("미션 POST 요청");
     console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -82,6 +82,45 @@ export const handleUserSignUp = async (req, res, next) => {
 };
 
 export const handleListMemberReviews = async (req, res, next) => {
+  /*
+    #swagger.tags = ["Member"];
+    #swagger.summary = '멤버 별 리뷰 목록 조회 API';
+    #swagger.parameters["cursor"] = { description: "Default 0, pagination/cursor 값을 다음 응답으로 넣어주세요." }
+    #swagger.responses[200] = {
+      description: "내 리뷰 목록 조회 성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            allOf: [ { $ref: "#/components/schemas/CommonSuccessResponse" }, {
+              type: "object",
+              properties: {
+                success: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: { type: "object", 
+                        properties: {
+                          id: { type: "number" }, 
+                          description: { type: "string"},
+                          starPoint: { type: "number" },
+                          store: { type: "object", properties: {
+                            id: { type: "number" }, 
+                            name: { type: "string" }
+                          }}
+                        }
+                      }
+                    },
+                    pagination: { type: "object", properties: { cursor: { type: "number", nullable: true } }}
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }
+    };
+  */
   try {
     const reviews = await listMemberReviews(
       typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -4,24 +4,13 @@ import { userSignUp, listMemberReviews } from "../services/user.service.js";
 
 export const handleUserSignUp = async (req, res, next) => {
     /*
+    #swagger.tags = ["Member"];
     #swagger.summary = '회원 가입 API';
     #swagger.requestBody = {
       required: true,
       content: {
         "application/json": {
-          schema: {
-            type: "object",
-            properties: {
-              email: { type: "string" },
-              name: { type: "string" },
-              gender: { type: "string" },
-              birth: { type: "string", format: "date" },
-              address: { type: "string" },
-              detailAddress: { type: "string" },
-              phoneNumber: { type: "string" },
-              preferences: { type: "array", items: { type: "number" } }
-            }
-          }
+          schema: { $ref: "#/components/schemas/SignUpUserRequest" }
         }
       }
     };
@@ -30,19 +19,22 @@ export const handleUserSignUp = async (req, res, next) => {
       content: {
         "application/json": {
           schema: {
-            type: "object",
-            properties: {
-              resultType: { type: "string", example: "SUCCESS" },
-              error: { type: "object", nullable: true, example: null },
-              success: {
+            allOf: [
+              { $ref : "#/components/schemas/CommonSuccessResponse" },
+              {
                 type: "object",
                 properties: {
-                  name: { type: "string" },
-                  email: { type: "string" },
-                  preferCategory: { type: "array", items: { type: "string" } }
+                  success: { 
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                      email: { type: "string" },
+                      preferCategory: { type: "array", items: { type: "string" } }
+                    }
+                  }
                 }
               }
-            }
+            ]
           }
         }
       }
@@ -52,19 +44,27 @@ export const handleUserSignUp = async (req, res, next) => {
       content: {
         "application/json": {
           schema: {
-            type: "object",
-            properties: {
-              resultType: { type: "string", example: "FAIL" },
-              error: {
+            allOf: [
+              { $ref: "#/components/schemas/CommonFailureResponse" },
+              {
                 type: "object",
                 properties: {
-                  errorCode: { type: "string", example: "U001" },
-                  reason: { type: "string" },
-                  data: { type: "object" }
+                  error: {
+                    type: "object",
+                    properties: {
+                      errorCode: { example : "U001" },
+                      reason: { example: "이미 존재하는 이메일입니다." },
+                      data: {
+                        type: "object",
+                        properties: {
+                          email: { type: "string", example: "test@example.com" }
+                        }
+                      }
+                    }
+                  }
                 }
-              },
-              success: { type: "object", nullable: true, example: null }
-            }
+              }
+            ]
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
-import swaggerAutogen from 'swagger-autogen';
 import swaggerUiExpress from 'swagger-ui-express';
 import {
   handleUserSignUp,
@@ -14,6 +13,7 @@ import {
   handleListStoreMissions
 } from './controllers/store.controller.js';
 import { handleMissionChallenge, handleMissionSuccess } from './controllers/mission.controller.js';
+import { swaggerHandler } from './utills/swagger/swagger.config.js';
 
 dotenv.config();
 
@@ -36,26 +36,7 @@ app.use(
   })
 );
 
-app.get("/openapi.json", async (req, res, next) => {
-  // #swagger.ignore = true
-  const options = {
-    openapi: "3.0.0",
-    disableLogs: true,
-    writeOutputFile: false,
-  };
-  const outputFile = "/dev/null"; // 파일 출력은 사용하지 않습니다.
-  const routes = ["./src/index.js"];
-  const doc = {
-    info: {
-      title: "UMC 8th",
-      description: "UMC 8th Node.js 테스트 프로젝트입니다.",
-    },
-    host: "localhost:3000",
-  };
-
-  const result = await swaggerAutogen(options)(outputFile, routes, doc);
-  res.json(result ? result.data : null);
-});
+app.get('/openapi.json', swaggerHandler);
 
 /* 공통 응답을 사용할 수 있는 헬퍼 함수 등록 */
 app.use((req, res, next) => {

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -49,6 +49,7 @@ export const getAllReviewsByMember = async(userId, cursor) => {
     select: {
       id: true,
       description: true,
+      starPoint: true,
       store: {
         select: {
           id: true,

--- a/src/utills/swagger/components/schemas.js
+++ b/src/utills/swagger/components/schemas.js
@@ -39,3 +39,20 @@ export const SignUpUserRequest = {
         preferences: { type: "array", items: { type: "number" } }
     }
 }
+
+export const Mission = {
+    type: "object",
+    properties: {
+        cond: { type: "number" },
+        reward: { type: "number" },
+        deadline: { type: "string", format: "date" }    
+    }
+};
+
+export const Review = {
+    type: "object",
+    properties: {
+        starPoint: { type: "number" },
+        content: { type: "string" }     
+    }
+}

--- a/src/utills/swagger/components/schemas.js
+++ b/src/utills/swagger/components/schemas.js
@@ -1,0 +1,41 @@
+/* 공통 응답 - SUCCESS */
+export const CommonSuccessResponse = {
+    type: "object",
+    properties: {
+        resultType: { type: "string", example: "SUCCESS" },
+        error: { type: "object", nullable: true, example: null },
+        success: { type: "object" },
+    }
+};
+
+/* 공통 응답 - FAIL */
+export const CommonFailureResponse = {
+    type: "object",
+    properties: {
+        resultType: { type: "string", example: "FAIL" },
+        error: {
+            type: "object",
+            properties: {
+                errorCode: { type: "string" },
+                reason: { type: "string" },
+                data: { type: "object" }
+            }
+        },
+        success: { type: "object", nullable: true, example: null },
+    }
+};
+
+/* 회원 가입 RequestBody */
+export const SignUpUserRequest = {
+    type: "object",
+    properties: {
+        email: { type: "string" },
+        name: { type: "string" },
+        gender: { type: "string" },
+        birth: { type: "string", format: "date" },
+        address: { type: "string" },
+        detailAddress: { type: "string" },
+        phoneNumber: { type: "string" },
+        preferences: { type: "array", items: { type: "number" } }
+    }
+}

--- a/src/utills/swagger/swagger.config.js
+++ b/src/utills/swagger/swagger.config.js
@@ -1,0 +1,34 @@
+import swaggerAutogen from "swagger-autogen";
+import * as schemas from './components/schemas.js';
+
+const doc = {
+    info: {
+      title: "UMC 8th",
+      description: "UMC 8th Node.js 테스트 프로젝트입니다.",
+    },
+    host: "localhost:3000",
+    components: {
+        schemas,
+    },
+};
+
+const routes = ['./src/index.js'];
+
+const swaggerHandler = async (req, res, next) => {
+// #swagger.ignore = true
+  const options = {
+    openapi: "3.0.0",
+    disableLogs: true,
+    writeOutputFile: false,
+  };
+  const outputFile = "/dev/null"; // 파일 출력은 사용하지 않습니다.
+  
+  try {
+    const result = await swaggerAutogen(options)(outputFile, routes, doc);
+    res.json(result ? result.data : null); 
+  } catch (err) {
+    next(err);
+  }
+};
+
+export { swaggerHandler };


### PR DESCRIPTION
## 📌 Issue Number

- close #32 

## ✅ 구현 내용

- 기존 구현한 API에 대한 Swagger 명세 작성
- OpenAPI Componet/Schema를 적용할 수 있도록 디렉토리 구조 리팩토링
- Component와 Schema를 사용하여 중복되는 코드를 줄임.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/065e34ac-dbff-4204-975f-730482d7be2e)
![image](https://github.com/user-attachments/assets/6fbbacbe-cc31-433e-b2ed-4da8fb5dc8c8)

## 📝  메모
- cursor의 description 등과 같은 공통된 사항을 options.js와 같은 형태로 중복 제거가 가능하다.
- 현재 리뷰 별점(1~5 사이)에 대한 validation이 없는 상태임.
- 리뷰 목록 조회 API의 응답에 별점에 대한 응답이 빠져있어 수정함.
- 두 개 이상에서 중복되는 형태만 컴포넌트로 처리할 수 있도록 하였음.